### PR TITLE
Adapt parsers to Openfisca 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.2 – [diff](https://github.com/openfisca/openfisca-parsers/compare/0.5.1...0.5.2)
+
+* Apply core API changes introduced by openfisca-core 2.0
+
 ## 0.5.1 – [diff](https://github.com/openfisca/openfisca-parsers/compare/0.5.0...0.5.1)
 
 * Force updating version number and CHANGELOG.md before merging on master

--- a/openfisca_parsers/formulas_parsers_2to3.py
+++ b/openfisca_parsers/formulas_parsers_2to3.py
@@ -736,7 +736,7 @@ class Call(AbstractWrapper):
                             return parser.CompactNode(
                                 is_reference = bool(reference),
                                 parser = parser,
-                                value = parser.tax_benefit_system.legislation_json,
+                                value = parser.tax_benefit_system.get_legislation(),
                                 )
         elif issubclass(parser.Date, expected):
             function = self.subject.guess(parser.Variable)
@@ -2081,7 +2081,7 @@ class Module(AbstractWrapper):
                 value = parser.Type(parser = parser, value = np.int32)),
             izip = parser.Variable(container = self, name = u'izip', parser = parser),
             law = parser.Variable(container = self, name = u'law', parser = parser,
-                value = parser.CompactNode(parser = parser, value = parser.tax_benefit_system.legislation_json)),
+                value = parser.CompactNode(parser = parser, value = parser.tax_benefit_system.get_legislation())),
             len = parser.Variable(container = self, name = u'len', parser = parser),
             log = parser.Variable(container = self, name = u'log', parser = parser,
                 value = parser.Logger(parser = parser)),

--- a/openfisca_parsers/formulas_parsers_2to3.py
+++ b/openfisca_parsers/formulas_parsers_2to3.py
@@ -2981,7 +2981,7 @@ class Parser(conv.State):
                             unicode(value).encode('utf-8'))
                     item_value = self.parse_value(dict_children[child_index + 2], container = container)
                     child_index += 3
-                    if dict_children[child_index].type == tokens.COMMA:
+                    if (child_index < len(dict_children)) and dict_children[child_index].type == tokens.COMMA:
                         child_index += 1
                     else:
                         assert child_index == len(dict_children), \

--- a/openfisca_parsers/scripts/formulas_to_julia.py
+++ b/openfisca_parsers/scripts/formulas_to_julia.py
@@ -1005,7 +1005,7 @@ class Call(JuliaCompilerMixin, formulas_parsers_2to3.Call):
                             hint = parser.CompactNode(
                                 is_reference = bool(reference),
                                 parser = parser,
-                                value = parser.tax_benefit_system.legislation_json,
+                                value = parser.tax_benefit_system.get_legislation(),
                                 ),
                             named_arguments = dict(reference = reference) if reference is not None else None,
                             parser = parser,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Parsers',
-    version = '0.5.1',
+    version = '0.5.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],
@@ -55,7 +55,7 @@ setup(
 
     install_requires = [
         'Biryani[datetimeconv] >= 0.10.1',
-        'OpenFisca-Core >= 0.5.0',
+        'OpenFisca-Core ~= 2.0',
         'numpy >= 1.6',
         ],
     packages = find_packages(),


### PR DESCRIPTION
Apply core API changes introduced by [openfisca-core 2.0](https://github.com/openfisca/openfisca-core/pull/388)
