### PR TITLE
Fix parsers dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.4 – [diff](https://github.com/openfisca/openfisca-core/compare/0.5.3...0.5.4)
+
+* Fix too strict dependency to core
+
 ## 0.5.3 – [diff](https://github.com/openfisca/openfisca-core/compare/0.5.2...0.5.3)
 
 * Update numpy dependency to 1.11

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Parsers',
-    version = '0.5.3',
+    version = '0.5.4',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],
@@ -55,7 +55,7 @@ setup(
 
     install_requires = [
         'Biryani[datetimeconv] >= 0.10.1',
-        'OpenFisca-Core ~= 2.0.2',
+        'OpenFisca-Core >= 2.0.2, < 3.0',
         'numpy >= 1.11',
         ],
     packages = find_packages(),


### PR DESCRIPTION
Was creating irrelevant version conflicts

`~= 2.0.2` doesn't allow us to use `2.1.0`.
pip doesn't offer the semver-style `^2.0.2`, so we have to explicit everything.
