### PR TITLE
Remove direct calls to Core and dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.2
+
+* Remove direct calls to Core.
+
 ## 1.0.1
 
 * Declare this package compatible with `core#5` 

--- a/openfisca_parsers/formulas_parsers_2to3.py
+++ b/openfisca_parsers/formulas_parsers_2to3.py
@@ -37,8 +37,8 @@ import lib2to3.pytree
 import os
 import textwrap
 
+from biryani.states import State
 import numpy as np
-from openfisca_core import conv
 
 
 symbols = lib2to3.pygram.python_symbols  # Note: symbols is a module.
@@ -2734,7 +2734,7 @@ class FormulaFunction(Function):
 # Default Parser
 
 
-class Parser(conv.State):
+class Parser(State):
     AndExpression = AndExpression
     AndTest = AndTest
     Array = Array

--- a/openfisca_parsers/input_variables_extractors.py
+++ b/openfisca_parsers/input_variables_extractors.py
@@ -31,8 +31,6 @@ import lib2to3.pygram
 import lib2to3.pytree
 import logging
 
-from openfisca_core import formulas
-
 from . import formulas_parsers_2to3
 
 
@@ -88,8 +86,7 @@ class Parser(formulas_parsers_2to3.Parser):
     def get_input_variables_and_parameters(self, column):
         formula_class = column.formula_class
         assert formula_class is not None, "Column {} has no formula".format(column.name)
-        if issubclass(formula_class, formulas.SimpleFormula) and formula_class.function is None:
-            # Input variable
+        if column.is_input_variable():
             return None, None
         self.column = column
         self.input_variables = input_variables = set()

--- a/openfisca_parsers/source_formulas_extractors.py
+++ b/openfisca_parsers/source_formulas_extractors.py
@@ -31,8 +31,6 @@ import lib2to3.pygram
 import lib2to3.pytree
 import logging
 
-from openfisca_core import formulas
-
 from . import formulas_parsers_2to3
 
 
@@ -77,8 +75,7 @@ class Parser(formulas_parsers_2to3.Parser):
     def get_source_formulas(self, column):
         formula_class = column.formula_class
         assert formula_class is not None, "Column {} has no formula".format(column.name)
-        if issubclass(formula_class, formulas.SimpleFormula) and formula_class.function is None:
-            # Input variable
+        if column.is_input_variable():
             return None
         self.column = column
         self.source_formulas = source_formulas = set()

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ doc_lines = __doc__.split('\n')
 
 setup(
     name = 'OpenFisca-Parsers',
-    version = '1.0.1',
+    version = '1.0.2',
     author = 'OpenFisca Team',
     author_email = 'contact@openfisca.fr',
     classifiers = [classifier for classifier in classifiers.split('\n') if classifier],

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
 
     install_requires = [
         'Biryani[datetimeconv] >= 0.10.1',
-        'OpenFisca-Core >= 4.0.0b1, < 6.0',
         'numpy >= 1.11',
         ],
     packages = find_packages(),


### PR DESCRIPTION
Connected to openfisca/openfisca-core#472

This PR removes direct calls to Core.

In a previous PR we had to release OpenFisca-Parsers just to make it compatible with OpenFisca-Core >= 5.0.0 which seems strange.

So we would like with @fpagnoux remove the dependency from OpenFisca-Parsers to OpenFisca-Core (see [`setup.py`](https://github.com/openfisca/openfisca-parsers/blob/5bf964aa99db96a94b28afa473d618cc7e725d7f/setup.py#L34)).

Is the fact that there are no direct calls anymore, a sufficient reason to remove the dependency to Core? For example the method [`Column.is_input_variable`](https://github.com/openfisca/openfisca-parsers/blob/611c05e2115a98660030039e5e6c81d523184e47/openfisca_parsers/input_variables_extractors.py#L89) remains, and [comes from the Core](https://github.com/openfisca/openfisca-core/blob/4ddc0648cfef10c888cc434b284a8e493488d90a/openfisca_core/columns.py#L74-L77), so I think that this materializes as a dependency.

As a conclusion I keep the dependency from Parsers to Core for now, accepting to publish compatibility releases.

Moreover would all this mean that Parsers and Core are strongly coupled, so Parsers should be committed under `openfisca_core.parsers`?

PS: in Python no concept of *peer dependency* seems to exist.